### PR TITLE
Get minimal WASM build working

### DIFF
--- a/bats.toml
+++ b/bats.toml
@@ -9,6 +9,3 @@ unsafe = false
 "builder" = ""
 "result" = ""
 "str" = ""
-"wasm.bats-packages.dev/bridge" = ""
-"promise" = ""
-"file" = ""

--- a/src/bin/quire.bats
+++ b/src/bin/quire.bats
@@ -3,6 +3,5 @@
 #include "share/atspre_staload.hats"
 
 #use builder as B
-#use wasm.bats-packages.dev/bridge as BR
 
 implement main0 () = ()

--- a/src/views.bats
+++ b/src/views.bats
@@ -5,7 +5,6 @@
 #use array as A
 #use arith as AR
 #use builder as B
-#use wasm.bats-packages.dev/bridge as BR
 
 (* ============================================================
    Library view: empty state with import button
@@ -14,7 +13,9 @@
 (* Render the library view into the DOM diff buffer.
    For Phase 1, this just renders the empty library message
    and import button. *)
-#pub fn render_library_empty(buf: !$A.arr(byte, l, 524288)): void
+#pub fn render_library_empty
+  {l:agz}
+  (buf: !$A.arr(byte, l, 524288)): void
 
 (* ============================================================
    Implementations


### PR DESCRIPTION
## Summary
- Remove bridge dep temporarily (blocked by compiler shared module issue)
- Fix views.bats quantifier
- WASM build now produces dist/wasm/app.wasm (1.2KB minimal binary)

## Next steps
- Fix compiler to staload shared modules for deps
- Add bridge back
- Wire up entry point to render DOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)