### PR TITLE
Add bridge dependency back

### DIFF
--- a/bats.toml
+++ b/bats.toml
@@ -9,3 +9,6 @@ unsafe = false
 "builder" = ""
 "result" = ""
 "str" = ""
+"wasm.bats-packages.dev/bridge" = ""
+"promise" = ""
+"file" = ""

--- a/src/bin/quire.bats
+++ b/src/bin/quire.bats
@@ -3,5 +3,6 @@
 #include "share/atspre_staload.hats"
 
 #use builder as B
+#use wasm.bats-packages.dev/bridge as BR
 
 implement main0 () = ()


### PR DESCRIPTION
Bridge now works as dep with compiler staload fix. WASM builds.