### PR TITLE
Use auto-generated CSS classes via set_class and inject_css

### DIFF
--- a/e2e/smoke.spec.js
+++ b/e2e/smoke.spec.js
@@ -19,7 +19,7 @@ test.describe('Smoke', () => {
     page.on('pageerror', err => errors.push(err.message));
 
     await page.goto('/');
-    await page.waitForSelector('.library-list', { timeout: 15000 });
+    await page.waitForSelector('#qllc', { timeout: 15000 });
 
     expect(errors.length).toBe(0);
   });

--- a/src/bin/quire.bats
+++ b/src/bin/quire.bats
@@ -1,8 +1,14 @@
 #target wasm binary
 #include "share/atspre_staload.hats"
+#use css as C
 #use str as S
 #use wasm.bats-packages.dev/dom as D
 #use widget as W
+
+(* Class indices — class_text maps: 0->caa, 1->cab, 2->cac *)
+macdef CLS_LIBRARY_LIST = 0
+macdef CLS_EMPTY_LIB = 1
+macdef CLS_IMPORT_BTN = 2
 
 implement main0 () = let
   var tag = @[char][3]('d', 'i', 'v')
@@ -12,13 +18,20 @@ implement main0 () = let
   (* Root element *)
   val root = $W.Element($W.ElementNode($W.Root(), $W.Normal($W.Div()), ~1, 0, $W.NoneInt(), $W.NoneStr(), $W.WNil()))
 
+  (* Inject CSS stylesheet *)
+  var si_c = @[char][4]('q', 'c', 's', 's')
+  val si_id = $W.Generated($S.text_of_chars(si_c, 4), 4)
+  val @(root, css_diffs) = $W.inject_css(root, si_id, ".caa{display:flex;flex-direction:column;padding:16px}.cab{text-align:center;color:#888;padding:32px}.cac{display:inline-block;padding:8px 16px;background:#4a90d9;color:#fff;border-radius:4px;cursor:pointer}")
+  val () = $D.apply_list(doc, css_diffs)
+
   (* library-list container *)
   var ll_c = @[char][4]('q', 'l', 'l', 'c')
   val ll_id = $W.Generated($S.text_of_chars(ll_c, 4), 4)
   val ll = $W.Element($W.ElementNode(ll_id, $W.Normal($W.Div()), ~1, 0, $W.NoneInt(), $W.NoneStr(), $W.WNil()))
   val @(root, diff) = $W.add_child(root, ll)
   val () = $D.apply(doc, diff)
-  val () = $D.apply(doc, $W.set_class_name(ll_id, "library-list"))
+  val @(ll, diff) = $W.set_class(ll, CLS_LIBRARY_LIST)
+  val () = $D.apply(doc, diff)
 
   (* empty-lib message *)
   var el_c = @[char][4]('q', 'e', 'l', 'b')
@@ -26,7 +39,8 @@ implement main0 () = let
   val el = $W.Element($W.ElementNode(el_id, $W.Normal($W.Div()), ~1, 0, $W.NoneInt(), $W.NoneStr(), $W.WNil()))
   val @(_, diff) = $W.add_child(ll, el)
   val () = $D.apply(doc, diff)
-  val () = $D.apply(doc, $W.set_class_name(el_id, "empty-lib"))
+  val @(_, diff) = $W.set_class(el, CLS_EMPTY_LIB)
+  val () = $D.apply(doc, diff)
   val () = $D.apply(doc, $W.set_text_content(el_id, "Your library is empty"))
 
   (* import button *)
@@ -35,7 +49,8 @@ implement main0 () = let
   val ib = $W.Element($W.ElementNode(ib_id, $W.Normal($W.Div()), ~1, 0, $W.NoneInt(), $W.NoneStr(), $W.WNil()))
   val @(_, diff) = $W.add_child(ll, ib)
   val () = $D.apply(doc, diff)
-  val () = $D.apply(doc, $W.set_class_name(ib_id, "import-btn"))
+  val @(_, diff) = $W.set_class(ib, CLS_IMPORT_BTN)
+  val () = $D.apply(doc, diff)
   val () = $D.apply(doc, $W.set_text_content(ib_id, "Import EPUB"))
 
   (* hidden file input inside import button *)


### PR DESCRIPTION
## Summary
- Replace `set_class_name(id, "library-list")` with `set_class(widget, 0)` — class names auto-generated by `class_text` (0→caa, 1→cab, 2→cac)
- Inject CSS stylesheet via `inject_css` which creates a `<style>` element through the widget system
- E2e smoke test targets widget ID (`#qllc`) instead of class selector (`.library-list`)
- No hardcoded CSS class name strings in WASM source

## Test plan
- [x] `bats check` passes locally (native target)
- [x] `bats build` produces `dist/wasm/app.wasm` 
- [ ] CI green (e2e smoke test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)