### PR TITLE
Add README with GitHub Pages link, fix deploy cache

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/bats-bin
-          key: bats-from-c-v3-${{ runner.os }}-${{ hashFiles('.github/workflows/check.yml') }}
+          key: bats-from-c-v5-${{ runner.os }}-${{ hashFiles('.github/workflows/deploy.yml') }}
 
       - name: Build bats from C
         if: steps.cache-bats.outputs.cache-hit != 'true'

--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# Quire
+
+An EPUB e-reader built on the [bats-lang](https://github.com/bats-lang) ecosystem. Runs entirely in the browser as a WebAssembly progressive web app.
+
+**[Try Quire](https://bats-lang.github.io/quire/)**
+
+## Features
+
+- Import EPUB files from your device
+- Paginated chapter reading with click/tap navigation
+- Chapter-by-chapter progress tracking
+- Font size settings with persistence
+- Library view with book cards
+- Works offline as a PWA
+
+## Architecture
+
+Quire is written in [Bats](https://github.com/bats-lang/bats), a language that compiles to ATS2 and then to WebAssembly. The UI is rendered through a virtual DOM diffing protocol via the [bridge](https://github.com/bats-lang/bridge) package.
+
+Key packages used:
+- **widget** — virtual DOM tree and diff generation
+- **dom** — binary DOM protocol emitter
+- **bridge** — WASM-to-JS bridge with event handling
+- **css** — CSS class generation
+- **zip/decompress** — EPUB archive extraction
+- **xml-tree** — XML/OPF metadata parsing
+
+## Development
+
+```bash
+# Build WASM app
+bats build --only wasm --repository ../repository-prototype
+
+# Build PWA generator (native)
+bats build --only native --repository ../repository-prototype
+
+# Generate PWA shell
+mkdir -p dist/pwa && dist/debug/gen-pwa
+
+# Run e2e tests
+npx playwright test
+```
+
+## License
+
+See individual package repositories for license information.


### PR DESCRIPTION
## Summary
- README with features, architecture overview, dev instructions
- Link to https://bats-lang.github.io/quire/
- Fix deploy workflow cache key (v3 -> v5)

## Test plan
- [x] README renders correctly
- [ ] CI green
- [ ] Deploy workflow succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)